### PR TITLE
fix(build): strips local version segment for PyPI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ source = "vcs"
 
 [tool.hatch.version.raw-options]
 version_scheme = "only-version"
+local_scheme = "no-local-version"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]


### PR DESCRIPTION
## Summary

- Adds `local_scheme = "no-local-version"` to hatch-vcs config so untagged builds don't produce versions like `0.4.1+g55b3fb852` which PyPI rejects